### PR TITLE
Initial attempt to create csvcubed style jobs along-side the existing Jenkins Jobs

### DIFF
--- a/reposync/reposync.py
+++ b/reposync/reposync.py
@@ -247,7 +247,7 @@ def update_jenkins(base, path, creds, name, writeback, github_home, branch_ref):
             _ensure_jenkins_folder_exists(jenkins_server, csvcubed_job_folder_path)):
 
         # CSV-W Generation Job
-        csvw_gen_job_template = Template(resources.read_text(templates, 'jenkins_job_csvcubed_csvw_generation.xml'))
+        csvw_gen_job_template = Template(resources.read_text(templates, 'jenkins_job_csvcubed_generate_csvw.xml'))
         csvw_gen_job_config_xml = csvw_gen_job_template.substitute(github_home=github_home,
                                                                    git_clone_url=github_home + '.git',
                                                                    dataset_dir=name,

--- a/reposync/templates/jenkins_job_csvcubed_csvw2pmd.xml
+++ b/reposync/templates/jenkins_job_csvcubed_csvw2pmd.xml
@@ -1,0 +1,45 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.42">
+  <actions>
+    <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction plugin="pipeline-model-definition@1.9.3"/>
+    <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction plugin="pipeline-model-definition@1.9.3">
+      <jobProperties/>
+      <triggers/>
+      <parameters/>
+      <options/>
+    </org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction>
+  </actions>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+      <triggers>
+        <jenkins.triggers.ReverseBuildTrigger>
+          <spec></spec>
+          <upstreamProjects>${csvw_gen_job_name}</upstreamProjects>
+          <threshold>
+            <name>SUCCESS</name>
+            <ordinal>0</ordinal>
+            <color>BLUE</color>
+            <completeBuild>true</completeBuild>
+          </threshold>
+        </jenkins.triggers.ReverseBuildTrigger>
+      </triggers>
+    </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+  </properties>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2640.v00e79c8113de">
+    <script>
+      @Library(&apos;pmd@csvwlib-build&apos;) _
+
+      csvw2pmd {
+          csvwGenerationProjectName = &quot;${csvw_gen_job_name}&quot;
+          graphUriBase = &quot;${graph_uri_base}&quot;
+          resourcesUriBase = &quot;${resources_uri_base}&quot;
+          shouldPublish = false
+      }
+    </script>
+    <sandbox>true</sandbox>
+  </definition>
+  <triggers/>
+  <disabled>true</disabled>
+</flow-definition>

--- a/reposync/templates/jenkins_job_csvcubed_generate_csvw.xml
+++ b/reposync/templates/jenkins_job_csvcubed_generate_csvw.xml
@@ -55,11 +55,8 @@
                 </hudson.plugins.git.extensions.impl.PathRestriction>
             </extensions>
         </scm>
-          <script>
-            @Library(&apos;pmd@csvwlib-build&apos;) _
-            buildcsvw {}
-          </script>
-      <sandbox>true</sandbox>
+        <scriptPath>datasets/Jenkinsfile-csvcubed</scriptPath>
+        <lightweight>true</lightweight>
     </definition>
     <triggers/>
     <disabled>true</disabled>

--- a/reposync/templates/jenkins_job_csvcubed_generate_csvw.xml
+++ b/reposync/templates/jenkins_job_csvcubed_generate_csvw.xml
@@ -1,0 +1,66 @@
+<?xml version='1.1'?>
+<flow-definition plugin="workflow-job@2.40">
+    <actions>
+        <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction plugin="pipeline-model-definition@1.7.2"/>
+        <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction plugin="pipeline-model-definition@1.7.2">
+            <jobProperties/>
+            <triggers/>
+            <parameters/>
+            <options/>
+        </org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction>
+    </actions>
+    <description></description>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <jenkins.model.BuildDiscarderProperty>
+            <strategy class="hudson.tasks.LogRotator">
+                <daysToKeep>-1</daysToKeep>
+                <numToKeep>10</numToKeep>
+                <artifactDaysToKeep>-1</artifactDaysToKeep>
+                <artifactNumToKeep>-1</artifactNumToKeep>
+            </strategy>
+        </jenkins.model.BuildDiscarderProperty>
+        <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+            <triggers>
+                <com.cloudbees.jenkins.GitHubPushTrigger plugin="github@1.31.0">
+                    <spec></spec>
+                </com.cloudbees.jenkins.GitHubPushTrigger>
+            </triggers>
+        </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+        <hudson.plugins.jira.JiraProjectProperty plugin="jira@3.1.1"/>
+        <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.31.0">
+            <projectUrl>${github_home}</projectUrl>
+            <displayName></displayName>
+        </com.coravy.hudson.plugins.github.GithubProjectProperty>
+    </properties>
+    <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2640.v00e79c8113de">
+        <scm class="hudson.plugins.git.GitSCM" plugin="git@4.4.1">
+            <configVersion>2</configVersion>
+            <userRemoteConfigs>
+                <hudson.plugins.git.UserRemoteConfig>
+                    <url>${git_clone_url}</url>
+                </hudson.plugins.git.UserRemoteConfig>
+            </userRemoteConfigs>
+            <branches>
+                <hudson.plugins.git.BranchSpec>
+                    <name>${branch_ref}</name>
+                </hudson.plugins.git.BranchSpec>
+            </branches>
+            <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+            <submoduleCfg class="list"/>
+            <extensions>
+                <hudson.plugins.git.extensions.impl.PathRestriction>
+                    <includedRegions>datasets/${dataset_dir}/.*</includedRegions>
+                    <excludedRegions></excludedRegions>
+                </hudson.plugins.git.extensions.impl.PathRestriction>
+            </extensions>
+        </scm>
+          <script>
+            @Library(&apos;pmd@csvwlib-build&apos;) _
+            buildcsvw {}
+          </script>
+      <sandbox>true</sandbox>
+    </definition>
+    <triggers/>
+    <disabled>true</disabled>
+</flow-definition>


### PR DESCRIPTION
This PR adds alters airtable-utils such that when `repo-sync -j` is run, it automatically adds new csvcubed-style Jenkins pipelines for each dataset. These jobs are added in a disabled state to avoid them being triggered until the decision is made to switch an individual dataset from the legacy approach to the csvcubed pipeline approach. 

I've added some [Documentation on switching to the csvcubed pipelines](https://collaborate2.ons.gov.uk/confluence/display/PHEM/Switching+to+the+csvcubed+Jenkins+Pipeline) as part of this issue.

Satisfies https://github.com/GSS-Cogs/csvcubed/issues/200